### PR TITLE
Adds api tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,82 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  lint:
+    name: Lint code style
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - run: npm ci --prefer-offline --no-audit
+      - run: npm run lint
+
+  unit:
+    name: Unit tests (Jest)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - run: npm ci --prefer-offline --no-audit
+      - run: npm run test:unit
+
+  api:
+    name: API tests (Playwright)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - run: npm ci --prefer-offline --no-audit
+      - run: |
+          npx playwright install --with-deps
+          npm run test:api
+
+  e2e:
+    name: E2E & visual tests (Chrome)
+    needs: [unit, api]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - run: npm ci --prefer-offline --no-audit
+      - run: npx playwright install --with-deps
+
+      - name: Playwright e2e/visual (Chrome)
+        run: |
+          PLAYWRIGHT_HTML_REPORT=playwright-report \
+          npm run test:e2e && npm run test:visual
+
+      - name: Upload Playwright report & traces
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-artifacts-${{ github.run_id }}
+          path: |
+            playwright-report/
+            test-results/
+          retention-days: 14

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,6 @@ jobs:
 
   e2e:
     name: E2E & visual tests (Chrome)
-    needs: [unit, api]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -69,8 +68,8 @@ jobs:
 
       - name: Playwright e2e/visual (Chrome)
         run: |
-          PLAYWRIGHT_HTML_REPORT=playwright-report \
-          npm run test:e2e && npm run test:visual
+          npm run test:e2e
+          npm run test:visual
 
       - name: Upload Playwright report & traces
         uses: actions/upload-artifact@v4

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 # testing
 /coverage
 /test-results/
+/playwright-report
 
 # next.js
 /.next/

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -14,6 +14,11 @@ export default defineConfig({
     timeout: 120 * 1000,
   },
 
+  reporter: [
+    ["list"],
+    ["html", { outputFolder: "playwright-report", open: "never" }],
+  ],
+
   projects: [
     {
       name: "api",

--- a/src/app/api/hello/route.ts
+++ b/src/app/api/hello/route.ts
@@ -1,6 +1,75 @@
-import { NextResponse } from "next/server"
+import { NextRequest, NextResponse } from "next/server"
 
-// GET  /api/hello   →  { "name": "John Doe" }
+const MAX_NAME_LEN = 50
+
+/** Record returned to clients */
+export interface NameRecord {
+  id: number
+  name: string
+  createdAt: string // ISO timestamp
+}
+
+/**
+ * In-memory name store (demo only).
+ * NOTE: Resets whenever the server process restarts.
+ */
+const RECORDS: NameRecord[] = []
+let nextId = 1
+
+function nowISO(): string {
+  return new Date().toISOString()
+}
+
+function isValidName(name: string): boolean {
+  const n = name.trim()
+  return n.length > 0 && n.length <= MAX_NAME_LEN
+}
+
+function errorResponse(code: string, message: string, status = 400) {
+  return NextResponse.json({ error: message, code }, { status })
+}
+
+/** Safely pull a string `name` from unknown JSON. */
+function extractName(data: unknown): string | undefined {
+  if (typeof data !== "object" || data === null) return undefined
+  const maybe = (data as Record<string, unknown>).name
+  return typeof maybe === "string" ? maybe : undefined
+}
+
+/* --------------------------- GET /api/hello --------------------------- */
+/** Return the full list of submitted names. */
 export async function GET() {
-  return NextResponse.json({ name: "John Doe" })
+  return NextResponse.json({
+    items: RECORDS,
+    count: RECORDS.length,
+  })
+}
+
+/* --------------------------- POST /api/hello -------------------------- */
+/** Create a new name record. Body: { name: string } */
+export async function POST(req: NextRequest) {
+  let payload: unknown
+  try {
+    payload = await req.json()
+  } catch {
+    return errorResponse("BAD_JSON", "Request body must be valid JSON.")
+  }
+
+  const rawName = extractName(payload) ?? ""
+  const name = rawName.trim()
+
+  if (!isValidName(name)) {
+    return errorResponse(
+      "INVALID_NAME",
+      `Name must be 1-${MAX_NAME_LEN} characters.`
+    )
+  }
+
+  const record: NameRecord = { id: nextId++, name, createdAt: nowISO() }
+  RECORDS.push(record)
+
+  return NextResponse.json(record, {
+    status: 201,
+    headers: { Location: `/api/hello?id=${record.id}` },
+  })
 }

--- a/tests/api/api-hello.api.spec.ts
+++ b/tests/api/api-hello.api.spec.ts
@@ -1,11 +1,47 @@
 import { test, expect } from "@playwright/test"
 
-test("GET /api/hello returns default JSON", async ({ request }) => {
-  const res = await request.get("/api/hello")
+import { SAMPLE_NAMES, MAX_NAME_LEN } from "../lib/testData"
+import { makeLongName, INVALID_NAME_MSG } from "../helpers/testHelpers"
 
-  expect(res.ok()).toBeTruthy()
-  expect(res.status()).toBe(200)
+test.describe.serial("hello API (list + create)", () => {
+  let startingCount = 0
 
-  const body = await res.json()
-  expect(body).toEqual({ name: "John Doe" })
+  test("GET empty list", async ({ request }) => {
+    const res = await request.get("/api/hello")
+    expect(res.status()).toBe(200)
+    const body = await res.json()
+    expect(Array.isArray(body.items)).toBe(true)
+    startingCount = body.count
+  })
+
+  test("POST valid name", async ({ request }) => {
+    const res = await request.post("/api/hello", {
+      data: { name: SAMPLE_NAMES.gustavo },
+    })
+    expect(res.status()).toBe(201)
+    const record = await res.json()
+    expect(record.name).toBe(SAMPLE_NAMES.gustavo)
+    expect(typeof record.id).toBe("number")
+    expect(typeof record.createdAt).toBe("string")
+
+    const res2 = await request.get("/api/hello")
+    const body2 = await res2.json()
+    expect(body2.count).toBeGreaterThanOrEqual(startingCount + 1)
+
+    type NameRecord = { id: number; name: string; createdAt: string }
+    const found = (body2.items as NameRecord[]).some(
+      (r) => r.name === SAMPLE_NAMES.gustavo
+    )
+    expect(found).toBe(true)
+  })
+
+  test("POST invalid long name", async ({ request }) => {
+    const res = await request.post("/api/hello", {
+      data: { name: makeLongName() },
+    })
+    expect(res.status()).toBe(400)
+    const err = await res.json()
+    expect(err.code).toBe("INVALID_NAME")
+    expect(err.error).toBe(INVALID_NAME_MSG(MAX_NAME_LEN))
+  })
 })

--- a/tests/e2e/smoke.e2e.spec.ts
+++ b/tests/e2e/smoke.e2e.spec.ts
@@ -1,0 +1,7 @@
+import { test, expect } from "@playwright/test"
+
+test("homepage loads and shows Next.js banner", async ({ page }) => {
+  await page.goto("/")
+
+  await expect(page).toHaveTitle("Create Next App")
+})

--- a/tests/helpers/testHelpers.ts
+++ b/tests/helpers/testHelpers.ts
@@ -1,0 +1,10 @@
+import { MAX_NAME_LEN } from "../lib/testData"
+
+// API Test Helpers
+
+export function makeLongName(len = MAX_NAME_LEN + 1): string {
+  return "x".repeat(len)
+}
+
+export const INVALID_NAME_MSG = (len = MAX_NAME_LEN) =>
+  `Name must be 1-${len} characters.`

--- a/tests/lib/testData.ts
+++ b/tests/lib/testData.ts
@@ -1,0 +1,7 @@
+export const MAX_NAME_LEN = 50
+
+export const SAMPLE_NAMES = {
+  gustavo: "Gustavo",
+  ana: "Ana",
+  maria: "Maria",
+}


### PR DESCRIPTION
### What
This commit adds a ChatGPT-generated API, a Lib folder for organizing the project's helpers and test data, and finally the api tests itself. These tests were created by me, and I prompted GPT if we could standardize the tests, suggesting some changes to variables and a final check on "POST valid name" test.

### How to test
To test the API:
- run the env `npm run dev`
- run `curl -s http://localhost:3000/api/hello` 
- Result: Expect an empty list
- run `curl -s -i -X POST http://localhost:3000/api/hello \
  -H "Content-Type: application/json" \
  -d '{"name":"Gustavo"}'`` and then run again `curl -s http://localhost:3000/api/hello`
- Result: { "id": 1, "name": "Gustavo", "createdAt": "XXXX-XX-..." }

For the tests:
- Api CI run should be green