### PR TITLE
Fixes flakyness of add three name test on local env

### DIFF
--- a/tests/page-objects/HomePage.ts
+++ b/tests/page-objects/HomePage.ts
@@ -30,7 +30,12 @@ export class HomePage {
     await this.input.click({ force: true })
     await this.input.fill("")
     await this.input.fill(name)
-    await this.submitBtn.click()
+    await Promise.all([
+      this.page.waitForResponse(
+        (r) => r.url().endsWith("/api/hello") && r.request().method() === "POST"
+      ),
+      this.submitBtn.click(),
+    ])
   }
 
   async expectNameVisible(name: string) {


### PR DESCRIPTION
This PR solves the flakiness in the local environment of Add three names tests.
We are adding an await for the response of the post request, preventing the next add to be fired before the previous post is finished.